### PR TITLE
Fix github actions build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/setup-node@v2
+        with:
+           node-version: 15
       - uses: enriikke/gatsby-gh-pages-action@v2
         with:
-          access-token: ${{ secrets.ACCESS_TOKEN }}
+          access-token: x-access-token:${{ secrets.GITHUB_TOKEN }}
           deploy-branch: gh-pages

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "metafacture-blog",
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -20,7 +21,7 @@
         "gatsby-plugin-offline": "^4.0.0",
         "gatsby-plugin-react-helmet": "^4.0.0",
         "gatsby-plugin-sharp": "^3.0.0",
-        "gatsby-remark-autolink-headers": "^5.3.0",
+        "gatsby-remark-autolink-headers": "^4.11.0",
         "gatsby-remark-copy-linked-files": "^3.0.0",
         "gatsby-remark-images": "^4.0.0",
         "gatsby-remark-prismjs": "^4.0.0",
@@ -11447,9 +11448,9 @@
       }
     },
     "node_modules/gatsby-remark-autolink-headers": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/gatsby-remark-autolink-headers/-/gatsby-remark-autolink-headers-5.4.0.tgz",
-      "integrity": "sha512-VT0xkjEtAkXMKx+m/wKk+1P0rcFezxlt22LmihadMgZnqjKleX39DbXaBX/VzmlqDZTeYO1c4396pXopF6Wu5Q==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-autolink-headers/-/gatsby-remark-autolink-headers-4.11.0.tgz",
+      "integrity": "sha512-wklhIRpVQfv9xMPoSVKDl/DRLBzxKWr13PRQgw602zVmj/IdMzgVarJgU8aCzlyb3+JztlptnKE1U/htFs8HGQ==",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "github-slugger": "^1.3.0",
@@ -11458,10 +11459,10 @@
         "unist-util-visit": "^2.0.3"
       },
       "engines": {
-        "node": ">=14.15.0"
+        "node": ">=12.13.0"
       },
       "peerDependencies": {
-        "gatsby": "^4.0.0-next",
+        "gatsby": "^3.0.0-next.0",
         "react": "^16.9.0 || ^17.0.0",
         "react-dom": "^16.9.0 || ^17.0.0"
       }
@@ -33389,9 +33390,9 @@
       }
     },
     "gatsby-remark-autolink-headers": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/gatsby-remark-autolink-headers/-/gatsby-remark-autolink-headers-5.4.0.tgz",
-      "integrity": "sha512-VT0xkjEtAkXMKx+m/wKk+1P0rcFezxlt22LmihadMgZnqjKleX39DbXaBX/VzmlqDZTeYO1c4396pXopF6Wu5Q==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-autolink-headers/-/gatsby-remark-autolink-headers-4.11.0.tgz",
+      "integrity": "sha512-wklhIRpVQfv9xMPoSVKDl/DRLBzxKWr13PRQgw602zVmj/IdMzgVarJgU8aCzlyb3+JztlptnKE1U/htFs8HGQ==",
       "requires": {
         "@babel/runtime": "^7.15.4",
         "github-slugger": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "gatsby-plugin-offline": "^4.0.0",
     "gatsby-plugin-react-helmet": "^4.0.0",
     "gatsby-plugin-sharp": "^3.0.0",
-    "gatsby-remark-autolink-headers": "^5.3.0",
+    "gatsby-remark-autolink-headers": "^4.11.0",
     "gatsby-remark-copy-linked-files": "^3.0.0",
     "gatsby-remark-images": "^4.0.0",
     "gatsby-remark-prismjs": "^4.0.0",


### PR DESCRIPTION
Fix github actions build by setting node version to 15 and fix

> "fatal: could not read Password for 'https://***@github.com': No such device or address"

with the setting found in https://github.com/skohub-io/skohub-blog/blob/main/.github/workflows/deploy.yml. Thx @acka47!

Downgrade gatsby-remark-autolink-headers:
The Plugin gatsby-remark-autolink-headers was not compatible with gatsby version 3.14.6.

Resolves #20.
