### PR TITLE
fix rss path to be absolute

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -58,7 +58,7 @@ const Layout = ({ location, title, children  }) => {
         GitHub <FontAwesomeIcon icon={faGithub} style={{ color: `#000`}}/>
       </a>
       {` | `}
-      <a href="rss.xml">Feed</a>
+      <a href="/rss.xml">Feed</a>
     </div>
   )
 


### PR DESCRIPTION
currently the link is relative and link will be broken if clicked from a blog post