### PR TITLE
Add blog post for Metafacture release: Core 8.0.1

### DIFF
--- a/content/blog/metafacture-release_core-8.0.1
+++ b/content/blog/metafacture-release_core-8.0.1
@@ -8,7 +8,7 @@ authors: [{lastname: "Bülte",
 
 *Preamble*
 
-This post describes the new developments since the [release of metafacture-core 8.0.0](https://blog.metafacture.org/metafacture-releases_core-8.0.0/) in June 2025.
+This post describes the new developments since the [release of metafacture-core 8.0.0](https://blog.metafacture.org/metafacture-releases_core-8.0.0/) in March 2026.
 
 For release notes with downloadable CLI runner, see [GitHub release of metafacture-core-8.0.1](https://github.com/metafacture/metafacture-core/releases/tag/metafacture-core-8.0.1).
 

--- a/content/blog/metafacture-release_core-8.0.1
+++ b/content/blog/metafacture-release_core-8.0.1
@@ -1,0 +1,26 @@
+---
+title: "Metafacture release: Core 8.0.1"
+date: "2026-03-20"
+description: "Changes coming with the release of metafacture-core 8.0.1"
+authors: [{lastname: "Bülte",
+           firstname: "Tobias"}]
+---
+
+*Preamble*
+
+This post describes the new developments since the [release of metafacture-core 8.0.0](https://blog.metafacture.org/metafacture-releases_core-8.0.0/) in June 2025.
+
+For release notes with downloadable CLI runner, see [GitHub release of metafacture-core-8.0.1](https://github.com/metafacture/metafacture-core/releases/tag/metafacture-core-8.0.1).
+
+## Table of Contents
+
+```toc
+# this will be replaced by the toc
+```
+
+## Bug fixes
+
+* Morph: Fix broken `<urlencode/>` [#705](https://github.com/metafacture/metafacture-core/issues/705)
+
+
+[Full change log](https://github.com/metafacture/metafacture-core/compare/metafacture-core-8.0.0...metafacture-core-8.0.1)


### PR DESCRIPTION
New blogpost for 8.0.1

Release: https://github.com/metafacture/metafacture-core/releases/tag/metafacture-core-8.0.1
Release issue: https://github.com/metafacture/metafacture-core/issues/752